### PR TITLE
Expand M4_HOOK_CONST_DEFINE into multiple macros for different types

### DIFF
--- a/src/c99-flex.skl
+++ b/src/c99-flex.skl
@@ -42,7 +42,15 @@ m4_define([[M4_HOOK_EOF_STATE_CASE_ARM]], [[	case YY_STATE_EOF($1):]])
 m4_define([[M4_HOOK_EOF_STATE_CASE_FALLTHROUGH]], [[		/* FALLTHROUGH */]])
 m4_define([[M4_HOOK_EOF_STATE_CASE_TERMINATE]], [[		yyterminate();
 ]])
-m4_define([[M4_HOOK_CONST_DEFINE]], [[const int $1 = $2;
+m4_define([[M4_HOOK_CONST_DEFINE_BYTE]], [[const char $1 = $2;
+]])
+m4_define([[M4_HOOK_CONST_DEFINE_STATE]], [[const yy_state_type $1 = $2;
+]])
+m4_define([[M4_HOOK_CONST_DEFINE_UINT]], [[const uint $1 = $2;
+]])
+m4_define([[M4_HOOK_CONST_DEFINE_BOOL]], [[const bool $1 = $2;
+]])
+m4_define([[M4_HOOK_CONST_DEFINE_UNKNOWN]], [[#define $1 $2
 ]])
 m4_define([[M4_HOOK_SET_YY_DECL]], [[#define YY_DECL $1
 ]])

--- a/src/cpp-flex.skl
+++ b/src/cpp-flex.skl
@@ -44,7 +44,15 @@ m4_define([[M4_HOOK_EOF_STATE_CASE_ARM]], [[	case YY_STATE_EOF($1):]])
 m4_define([[M4_HOOK_EOF_STATE_CASE_FALLTHROUGH]], [[		/* FALLTHROUGH */]])
 m4_define([[M4_HOOK_EOF_STATE_CASE_TERMINATE]], [[		yyterminate();
 ]])
-m4_define([[M4_HOOK_CONST_DEFINE]], [[#define $1 $2
+m4_define([[M4_HOOK_CONST_DEFINE_BYTE]], [[#define $1 $2
+]])
+m4_define([[M4_HOOK_CONST_DEFINE_STATE]], [[#define $1 $2
+]])
+m4_define([[M4_HOOK_CONST_DEFINE_UINT]], [[#define $1 $2
+]])
+m4_define([[M4_HOOK_CONST_DEFINE_BOOL]], [[#define $1 $2
+]])
+m4_define([[M4_HOOK_CONST_DEFINE_UNKNOWN]], [[#define $1 $2
 ]])
 m4_define([[M4_HOOK_SET_OFFSET_TYPE]], [[#define YY_OFFSET_TYPE $1
 ]])

--- a/src/main.c
+++ b/src/main.c
@@ -197,11 +197,11 @@ int flex_main (int argc, char *argv[])
 	out ("\n");
 
 	comment("START of Flex-generated definitions\n");
-	out_str_dec ("M4_HOOK_CONST_DEFINE(%s, %d)", "YY_NUM_RULES", num_rules);
-	out_str_dec ("M4_HOOK_CONST_DEFINE(%s, %d)", "YY_END_OF_BUFFER", num_rules + 1);
-	out_str_dec ("M4_HOOK_CONST_DEFINE(%s, %d)", "YY_JAMBASE", jambase);
-	out_str_dec ("M4_HOOK_CONST_DEFINE(%s, %d)", "YY_JAMSTATE", jamstate);
-	out_str_dec ("M4_HOOK_CONST_DEFINE(%s, %d)", "YY_NUL_EC", NUL_ec);
+	out_str_dec ("M4_HOOK_CONST_DEFINE_UINT(%s, %d)", "YY_NUM_RULES", num_rules);
+	out_str_dec ("M4_HOOK_CONST_DEFINE_STATE(%s, %d)", "YY_END_OF_BUFFER", num_rules + 1);
+	out_str_dec ("M4_HOOK_CONST_DEFINE_STATE(%s, %d)", "YY_JAMBASE", jambase);
+	out_str_dec ("M4_HOOK_CONST_DEFINE_STATE(%s, %d)", "YY_JAMSTATE", jamstate);
+	out_str_dec ("M4_HOOK_CONST_DEFINE_BYTE(%s, %d)", "YY_NUL_EC", NUL_ec);
 	/* Need to define the transet type as a size large
 	 * enough to hold the biggest offset.
 	 */
@@ -1044,7 +1044,7 @@ void flexinit (int argc, char **argv)
 			    if (*def == '\0')
 				    def = "1";
 
-			    snprintf(buf2, sizeof(buf2), "M4_HOOK_CONST_DEFINE(%s, %s)", arg, def);
+			    snprintf(buf2, sizeof(buf2), "M4_HOOK_CONST_DEFINE_UNKNOWN(%s, %s)", arg, def);
 			    buf_strappend (&userdef_buf, buf2);
 		    }
 		    break;
@@ -1307,9 +1307,9 @@ void readin (void)
 	}
 
 	if (ctrl.yylmax != 0) {
-		out_dec ("M4_CONST_DEFINE(YYLMAX, %d)\n", ctrl.yylmax);
+		out_dec ("M4_HOOK_CONST_DEFINE_UINT(YYLMAX, %d)\n", ctrl.yylmax);
 	}
-	
+
 	/* Dump the user defined preproc directives. */
 	if (userdef_buf.elts)
 		outn ((char *) (userdef_buf.elts));
@@ -1439,7 +1439,7 @@ void readin (void)
 		int i;
 		buf_init(&tmpbuf, sizeof(char));
 		for (i = 1; i <= lastsc; i++) {
-			char *str, *fmt = "M4_HOOK_CONST_DEFINE(%s, %d)";
+			char *str, *fmt = "M4_HOOK_CONST_DEFINE_STATE(%s, %d)";
 			size_t strsz;
 
 			strsz = strlen(fmt) + strlen(scname[i]) + (size_t)(1 + ceil (log10(i))) + 2;


### PR DESCRIPTION
The Rust backend needs to know the type of every constant; it can't
just guess and it doesn't have text macros like C.