### PR TITLE
check that each skeleton we build has the correct number of sections

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -99,14 +99,17 @@ clean-local:
 
 cpp-flex.h: cpp-flex.skl mkskel.sh flexint_shared.h tables_shared.h tables_shared.c
 	$(SHELL) $(srcdir)/mkskel.sh cpp $(srcdir) $(m4) $(VERSION) > $@.tmp
+	$(SHELL) $(srcdir)/chkskel.sh $@.tmp
 	mv -f $@.tmp $@
 
 c99-flex.h: c99-flex.skl mkskel.sh
 	$(SHELL) $(srcdir)/mkskel.sh c99 $(srcdir) $(m4) $(VERSION) > $@.tmp
+	$(SHELL) $(srcdir)/chkskel.sh $@.tmp
 	mv -f $@.tmp $@
 
 go-flex.h: go-flex.skl mkskel.sh
 	$(SHELL) $(srcdir)/mkskel.sh go $(srcdir) $(m4) $(VERSION) > $@.tmp
+	$(SHELL) $(srcdir)/chkskel.sh $@.tmp
 	mv -f $@.tmp $@
 
 if ENABLE_BOOTSTRAP

--- a/src/chkskel.sh
+++ b/src/chkskel.sh
@@ -1,0 +1,33 @@
+#! /bin/sh
+
+#  This file is part of flex.
+
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions
+#  are met:
+
+#  1. Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+#  2. Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+
+#  Neither the name of the University nor the names of its contributors
+#  may be used to endorse or promote products derived from this software
+#  without specific prior written permission.
+
+#  THIS SOFTWARE IS PROVIDED ``AS IS'' AND WITHOUT ANY EXPRESS OR
+#  IMPLIED WARRANTIES, INCLUDING, WITHOUT LIMITATION, THE IMPLIED
+#  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+#  PURPOSE.
+
+if test ! $# = 1; then
+   echo 'Usage: chkskel.sh file' >&2
+   exit 1
+fi
+file=$1
+lines=$(grep -c '^  "%%' "${file}")
+if [ ! "${lines}" -eq 6 ]; then
+    echo 'ERROR: skeleton does not have the right number of %% section lines'
+    exit 2
+fi


### PR DESCRIPTION
Probably we could turn the section markers into m4 macros, but until
then this will prevent accidents.